### PR TITLE
Added explicit dependencies between tasks

### DIFF
--- a/columns-parser/build.gradle.kts
+++ b/columns-parser/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.strumenta.antlrkotlin.gradle.AntlrKotlinTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompileCommon
 
 buildscript {
     repositories {
@@ -96,6 +98,17 @@ val generateKotlinCommonGrammarSource = tasks.register<AntlrKotlinTask>("generat
     ).get().asFile
     // use this settings if you want to add the generated sources to version control
     // outputDirectory = File("src/commonAntlr/kotlin")
+}
+
+
+tasks.withType<KotlinCompileCommon> {
+    dependsOn(generateKotlinCommonGrammarSource)
+    inputs.files(generateKotlinCommonGrammarSource.get().outputs.files)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    dependsOn(generateKotlinCommonGrammarSource)
+    inputs.files(generateKotlinCommonGrammarSource.get().outputs.files)
 }
 
 tasks.getByName("compileKotlinJvm").dependsOn(generateKotlinCommonGrammarSource)


### PR DESCRIPTION
Under Linux, the gradle setup reports, that there is a implicit dependency problem:

```
* What went wrong:
A problem was found with the configuration of task ':columns-parser:compileCommonMainKotlinMetadata' (type 'KotlinCompileCommon').
  - Gradle detected a problem with the following location: 'FhirExtinguisher/columns-parser/build/generatedAntlr'.
    
    Reason: Task ':columns-parser:compileCommonMainKotlinMetadata' uses this output of task ':columns-parser:generateKotlinCommonGrammarSource' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':columns-parser:generateKotlinCommonGrammarSource' as an input of ':columns-parser:compileCommonMainKotlinMetadata'.
      2. Declare an explicit dependency on ':columns-parser:generateKotlinCommonGrammarSource' from ':columns-parser:compileCommonMainKotlinMetadata' using Task#dependsOn.
      3. Declare an explicit dependency on ':columns-parser:generateKotlinCommonGrammarSource' from ':columns-parser:compileCommonMainKotlinMetadata' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.8/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

By explicitly adding the dependency, this can be fixed. 